### PR TITLE
make test script run another script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "https://github.com/TheAlphaNerd/omg-i-pass",
   "main": "index.js",
   "scripts": {
-    "test": "exit 0"
+    "pass": "exit 0",
+    "test": "npm run pass"
   },
   "keywords": [
     "always",


### PR DESCRIPTION
A very common pattern in packages is to delegate to other scripts from `npm test`.
Do it here to make sure we cover this case in CITGM tests.

@MylesBorins 